### PR TITLE
Updated variable names for Ghost 1.0 compatibility

### DIFF
--- a/author.hbs
+++ b/author.hbs
@@ -8,9 +8,9 @@
 {{! Everything inside the #author tags pulls data from the author }}
 {{#author}}
     <section class="author-profile inner">
-        {{#if image}}
+        {{#if profile_image}}
         <figure class="author-image">
-            <div class="img" style="background-image: url({{image}})"><span class="hidden">{{name}}'s Picture</span></div>
+            <div class="img" style="background-image: url({{img_url profile_image}})"><span class="hidden">{{name}}'s Picture</span></div>
         </figure>
         {{/if}}
         <h1 class="author-title">{{name}}</h1>

--- a/page.hbs
+++ b/page.hbs
@@ -13,10 +13,10 @@
 
 <main id="content" class="content" role="main">
 
-    <div id="article" class="box {{#if image}}has-image{{/if}}">
-        {{#if image}}
+    <div id="article" class="box {{#if feature_image}}has-image{{/if}}">
+        {{#if feature_image}}
         <div class="image-wrapper">
-            <img src="{{image}}" class="post-image"/>
+            <img src="{{img_url feature_image}}" class="post-image"/>
         </div>
         {{/if}}
     
@@ -39,9 +39,9 @@
         {{! Everything inside the #author tags pulls data from the author }}
         {{#author}}
 
-            {{#if image}}
+            {{#if profile_image}}
             <figure class="author-image">
-                <a class="img" href="{{url}}" style="background-image: url({{image}})"><span class="hidden">{{name}}'s Picture</span></a>
+                <a class="img" href="{{url}}" style="background-image: url({{img_url profile_image}})"><span class="hidden">{{name}}'s Picture</span></a>
             </figure>
             {{/if}}
 

--- a/partials/header.hbs
+++ b/partials/header.hbs
@@ -1,6 +1,6 @@
 {{! The big featured header }}
 <header id="header">
-    <nav class="header-nav" {{#if @blog.cover}}style="background-image:url({{@blog.cover}}){{/if}}">
+    <nav class="header-nav" {{#if @blog.cover_image}}style="background-image:url({{@blog.cover_image}}){{/if}}">
 
       <div class="blog-title"><a href="{{@blog.url}}">{{@blog.title}}</a></div>
 

--- a/partials/loop.hbs
+++ b/partials/loop.hbs
@@ -4,7 +4,7 @@
 
 <a class="article-link" href="{{url}}">
     <article class="box is-link {{post_class}}">
-        {{#if feauture_image}}
+        {{#if feature_image}}
             <section class="post-image" style="background-image:url({{img_url feature_image}})"></section>
         {{/if}}
         <header class="post-header">

--- a/partials/loop.hbs
+++ b/partials/loop.hbs
@@ -4,8 +4,8 @@
 
 <a class="article-link" href="{{url}}">
     <article class="box is-link {{post_class}}">
-        {{#if image}}
-            <section class="post-image" style="background-image:url({{image}})"></section>
+        {{#if feauture_image}}
+            <section class="post-image" style="background-image:url({{img_url feature_image}})"></section>
         {{/if}}
         <header class="post-header">
             <h2 class="post-title">{{{title}}}</h2>

--- a/post.hbs
+++ b/post.hbs
@@ -13,10 +13,10 @@
 
 <main id="content" class="content" role="main">
 
-    <div id="article" class="box {{#if image}}has-image{{/if}}">
-        {{#if image}}
+    <div id="article" class="box {{#if feature_image}}has-image{{/if}}">
+        {{#if feature_image}}
         <div class="image-wrapper">
-            <img src="{{image}}" class="post-image"/>
+            <img src="{{img_url feature_image}}" class="post-image"/>
         </div>
         {{/if}}
     
@@ -39,9 +39,9 @@
         {{! Everything inside the #author tags pulls data from the author }}
         {{#author}}
 
-            {{#if image}}
+            {{#if profile_image}}
             <figure class="author-image">
-                <a class="img" href="{{url}}" style="background-image: url({{image}})"><span class="hidden">{{name}}'s Picture</span></a>
+                <a class="img" href="{{url}}" style="background-image: url({{img_url profile_image}})"><span class="hidden">{{name}}'s Picture</span></a>
             </figure>
             {{/if}}
 


### PR DESCRIPTION
Changed the {{image}} variable to either profile_image or feature_image based on context. Switch @blog.cover to @blog.cover_image. No changes to template functionality or layout.

Activates without error on Ghost 1.0.