### PR TITLE
Fixed complains about CSS and Templates in Ghost 1.0

### DIFF
--- a/assets/css/screen.css
+++ b/assets/css/screen.css
@@ -503,8 +503,8 @@ margin on the iframe, cause it breaks stuff. */
 /* Hide when there's no cover image or on page2+ */
 .no-cover .scroll-down,
 .no-cover.main-header:after,
-.archive-template .scroll-down,
-.archive-template .main-header:after {
+.paged .scroll-down,
+.paged .main-header:after {
     display: none
 }
 
@@ -1140,7 +1140,7 @@ body:not(.post-template) .post-title {
 
 /* Turn off meta for page2+ to make room for extra
    pagination prev/next links */
-.archive-template .author-profile .author-meta {
+.paged .author-profile .author-meta {
     display: none;
 }
 
@@ -1222,12 +1222,12 @@ body:not(.post-template) .post-title {
 }
 
 /* On page2+ make all the headers smaller */
-.archive-template .main-header {
+.paged .main-header {
     max-height: 30%;
 }
 
 /* On page2+ show extra pagination controls at the top of post list */
-.archive-template .extra-pagination {
+.paged .extra-pagination {
     display: block;
 }
 
@@ -1298,7 +1298,7 @@ body:not(.post-template) .post-title {
     .scroll-down,
     .home-template .main-header:after { display: none; }
 
-    .archive-template .main-header {
+    .paged .main-header {
         min-height: 180px;
         padding: 10% 0;
     }
@@ -1410,7 +1410,7 @@ body:not(.post-template) .post-title {
         height: 30%;
     }
 
-    .archive-template .main-header {
+    .paged .main-header {
         max-height: 20%;
         min-height: 160px;
         padding: 10% 0;
@@ -1651,7 +1651,7 @@ body:not(.post-template) .post-title {
         font-size: 1.4rem;
     }
 
-    .archive-template .main-header .page-description {
+    .paged .main-header .page-description {
         display: none;
     }
 

--- a/default.hbs
+++ b/default.hbs
@@ -7,7 +7,6 @@
 
     {{! Page Meta }}
     <title>{{meta_title}}</title>
-    <meta name="description" content="{{meta_description}}" />
 
     <meta name="HandheldFriendly" content="True" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />


### PR DESCRIPTION
When Template is uploaded to 1.0 (Tested with 1.16.2)
one gets following errors:

* The usage of {{meta_description}} in HTML head is no longer required
* Replace .archive-template with the .paged CSS class

This patch fixes these.